### PR TITLE
Transactions

### DIFF
--- a/datastore_entity_derives/src/lib.rs
+++ b/datastore_entity_derives/src/lib.rs
@@ -314,7 +314,7 @@ pub fn datastore_managed(input: TokenStream) -> TokenStream {
                 #kind_str
             }
 
-            pub fn id(&self) -> core::option::Option<&google_datastore1::schemas::Key> {
+            pub fn id(&self) -> std::option::Option<&google_datastore1::schemas::Key> {
                 #self_key_field_expr
             }
 
@@ -349,7 +349,6 @@ pub fn datastore_managed(input: TokenStream) -> TokenStream {
             {
                 let result_entity = datastore_entity::commit_one(
                     self.into(),
-                    #kind_str.to_string(),
                     connection
                 )?;
                 let result: #name = result_entity
@@ -398,8 +397,20 @@ pub fn datastore_managed(input: TokenStream) -> TokenStream {
                 #(
                     #from_properties;
                 )*
+
+                fn generate_empty_key() -> std::option::Option<google_datastore1::schemas::Key> {
+                    Some(google_datastore1::schemas::Key {
+                        partition_id: None,
+                        path: Some(vec![google_datastore1::schemas::PathElement {
+                            id: None,
+                            kind: Some(#kind_str.to_string()),
+                            name: None,
+                        }]),
+                    })
+                }
+
                 datastore_entity::DatastoreEntity::from(
-                    #entity_key_field_expr,
+                    #entity_key_field_expr.or_else(generate_empty_key),
                     properties,
                 )
             }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -3,4 +3,9 @@ use google_datastore1::Client;
 pub trait DatastoreConnection {
     fn get_client(&self) -> &Client;
     fn get_project_name(&self) -> String;
+
+    // Id of ongoing transaction
+    fn get_transaction_id(&self) -> Option<String> {
+        None
+    }
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -4,7 +4,3 @@ pub trait DatastoreConnection {
     fn get_client(&self) -> &Client;
     fn get_project_name(&self) -> String;
 }
-
-
-
-

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -1,5 +1,6 @@
+use crate::error::{DatastoreParseError};
+
 use google_datastore1::schemas::{ArrayValue, Entity, Key, Value, Query};
-use thiserror::Error;
 
 use std::collections::BTreeMap;
 use std::convert::From;
@@ -7,19 +8,6 @@ use std::convert::TryFrom;
 use std::convert::TryInto;
 use std::fmt::{Display, Formatter};
 use std::ops::Deref;
-
-//
-// DatastoreEntity related errors
-//
-#[derive(Error, Debug, PartialEq)]
-pub enum DatastoreParseError {
-    #[error("value not found")]
-    NoSuchValue,
-    #[error("no properties found on entity")]
-    NoProperties,
-    #[error("unexpected type in array item")]
-    InvalidArrayValueFormat,
-}
 
 //
 // DatastoreValue

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,4 @@
-
-
 use thiserror::Error;
-
 
 //
 // DatastoreEntity related errors
@@ -12,10 +9,11 @@ pub enum DatastoreParseError {
     NoSuchValue,
     #[error("no properties found on entity")]
     NoProperties,
+    #[error("no data in result")]
+    NoResult,
     #[error("unexpected type in array item")]
     InvalidArrayValueFormat,
 }
-
 
 #[derive(Error, Debug, PartialEq)]
 pub enum DatastoreClientError {
@@ -29,6 +27,8 @@ pub enum DatastoreClientError {
     KeyAssignmentFailed,
     #[error("delete operation failed")]
     DeleteFailed,
+    #[error("data conflict detected in commit")]
+    DataConflict,
     #[error("unexpected response data")]
     ApiDataError,
     #[error("no more pages to fetch")]
@@ -42,5 +42,5 @@ pub enum DatastorersError {
     #[error(transparent)]
     DatastoreError(#[from] google_datastore1::Error),
     #[error(transparent)]
-    DatastoreClientError(#[from] DatastoreClientError)
+    DatastoreClientError(#[from] DatastoreClientError),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,6 +33,8 @@ pub enum DatastoreClientError {
     ApiDataError,
     #[error("no more pages to fetch")]
     NoMorePages,
+    #[error("cannot create transacion from transaction")]
+    TransactionInProgress,
 }
 
 #[derive(Error, Debug)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,46 @@
+
+
+use thiserror::Error;
+
+
+//
+// DatastoreEntity related errors
+//
+#[derive(Error, Debug, PartialEq)]
+pub enum DatastoreParseError {
+    #[error("value not found")]
+    NoSuchValue,
+    #[error("no properties found on entity")]
+    NoProperties,
+    #[error("unexpected type in array item")]
+    InvalidArrayValueFormat,
+}
+
+
+#[derive(Error, Debug, PartialEq)]
+pub enum DatastoreClientError {
+    #[error("entity not found")]
+    NotFound,
+    #[error("multiple entities found, single result expected")]
+    AmbigiousResult,
+    #[error("missing key, entity cannot be commited")]
+    KeyMissing,
+    #[error("failed to assign key to inserted entity")]
+    KeyAssignmentFailed,
+    #[error("delete operation failed")]
+    DeleteFailed,
+    #[error("unexpected response data")]
+    ApiDataError,
+    #[error("no more pages to fetch")]
+    NoMorePages,
+}
+
+#[derive(Error, Debug)]
+pub enum DatastorersError {
+    #[error(transparent)]
+    ParseError(#[from] DatastoreParseError),
+    #[error(transparent)]
+    DatastoreError(#[from] google_datastore1::Error),
+    #[error(transparent)]
+    DatastoreClientError(#[from] DatastoreClientError)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,12 @@
 pub mod connection;
 mod entity;
-pub use crate::entity::{DatastoreEntity, DatastoreProperties, DatastoreValue, DatastoreParseError, DatastoreEntityCollection, ResultCollection};
+pub mod error;
+pub use crate::entity::{DatastoreEntity, DatastoreProperties, DatastoreValue, DatastoreEntityCollection, ResultCollection};
 pub use crate::connection::{DatastoreConnection};
+pub use crate::error::{DatastoreParseError, DatastoreClientError, DatastorersError};
 
 pub use datastore_entity_derives::DatastoreManaged;
 
-use thiserror::Error;
 use google_datastore1::schemas::{
     BeginTransactionRequest, BeginTransactionResponse, CommitRequest, CommitResponse, Entity,
     Filter, Key, KindExpression, LookupRequest, LookupResponse, Mutation, PathElement,
@@ -17,34 +18,6 @@ use std::convert::TryInto;
 use std::convert::TryFrom;
 
 const DEFAULT_PAGE_SIZE: i32 = 50;
-
-#[derive(Error, Debug, PartialEq)]
-pub enum DatastoreClientError {
-    #[error("entity not found")]
-    NotFound,
-    #[error("multiple entities found, single result expected")]
-    AmbigiousResult,
-    #[error("missing key, entity cannot be commited")]
-    KeyMissing,
-    #[error("failed to assign key to inserted entity")]
-    KeyAssignmentFailed,
-    #[error("delete operation failed")]
-    DeleteFailed,
-    #[error("unexpected response data")]
-    ApiDataError,
-    #[error("no more pages to fetch")]
-    NoMorePages,
-}
-
-#[derive(Error, Debug)]
-pub enum DatastorersError {
-    #[error(transparent)]
-    ParseError(#[from] DatastoreParseError),
-    #[error(transparent)]
-    DatastoreError(#[from] google_datastore1::Error),
-    #[error(transparent)]
-    DatastoreClientError(#[from] DatastoreClientError)
-}
 
 
 pub fn get_one_by_id(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod connection;
 mod entity;
 pub mod error;
+pub mod transaction;
 pub use crate::connection::DatastoreConnection;
 pub use crate::entity::{
     DatastoreEntity, DatastoreEntityCollection, DatastoreProperties, DatastoreValue,
@@ -14,7 +15,7 @@ use google_datastore1::schemas::{
     BeginTransactionRequest, BeginTransactionResponse, CommitRequest, CommitResponse, Entity,
     Filter, Key, KindExpression, LookupRequest, LookupResponse, Mutation, MutationResult,
     PathElement, PropertyFilter, PropertyFilterOp, PropertyReference, Query,
-    QueryResultBatchMoreResults, RunQueryRequest, RunQueryResponse, Value,
+    QueryResultBatchMoreResults, RunQueryRequest, RunQueryResponse, Value, ReadOptions
 };
 
 use std::convert::TryFrom;
@@ -40,7 +41,10 @@ pub fn get_one_by_id(
     };
     let req = LookupRequest {
         keys: Some(vec![key]),
-        read_options: None,
+        read_options: Some(ReadOptions {
+            transaction: connection.get_transaction_id(),
+            read_consistency: None,
+        })
     };
     let resp: LookupResponse = projects
         .lookup(req, connection.get_project_name())
@@ -102,6 +106,10 @@ pub fn get_one_by_property(
         kind,
         1,
     ));
+    req.read_options = Some(ReadOptions{
+        transaction: connection.get_transaction_id(),
+        read_consistency: None,
+    });
 
     let resp: RunQueryResponse = projects
         .run_query(req, connection.get_project_name())

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,0 +1,118 @@
+use crate::connection::DatastoreConnection;
+use crate::error::{DatastoreClientError, DatastorersError};
+use crate::entity::{DatastoreEntity};
+
+use google_datastore1::Client;
+use google_datastore1::schemas::{
+  BeginTransactionRequest, BeginTransactionResponse, CommitRequest, CommitResponse, Entity,
+  Mutation,
+};
+
+use std::convert::TryInto;
+
+pub struct TransactionConnection<'a> {
+  connection: &'a dyn DatastoreConnection,
+  transaction_id: String,
+  mutations: Vec<Mutation>,
+}
+
+impl DatastoreConnection for TransactionConnection<'_> {
+
+  fn get_client(&self) -> &Client {
+    self.connection.get_client()
+  }
+  
+  fn get_project_name(&self) -> String {
+    self.connection.get_project_name()
+  }
+
+  
+  fn get_transaction_id(&self) -> Option<String> {
+      Some(self.transaction_id.clone())
+  }
+}
+
+
+impl TransactionConnection<'_> {
+
+  pub fn begin_transaction(connection: &impl DatastoreConnection) -> Result<TransactionConnection, DatastorersError> {
+    
+    if connection.get_transaction_id().is_some() {
+      // Transaction already in progress!
+      return Err(DatastoreClientError::TransactionInProgress)?
+    }
+
+    let client = connection.get_client();
+    let projects = client.projects();
+    let builder = projects.begin_transaction(
+        BeginTransactionRequest {
+            transaction_options: None,
+        },
+        connection.get_project_name(),
+    );
+    let begin_transaction: BeginTransactionResponse = builder.execute()?;
+
+    let transaction_id = begin_transaction.transaction.ok_or(DatastoreClientError::ApiDataError)?;
+    Ok(TransactionConnection {
+      connection,
+      transaction_id,
+      mutations: vec![],
+    })
+  }
+
+  pub fn save(&mut self, item: impl Into<DatastoreEntity>) -> Result<(), DatastorersError> {
+    let entity: DatastoreEntity = item.into();
+    let base_version = entity.version();
+    let ent: Entity = entity.try_into()?;
+
+    let mut mutation = Mutation::default();
+    mutation.upsert = Some(ent);  
+    mutation.base_version = base_version;
+
+    self.mutations.push(mutation);
+
+    Ok(())
+  }
+
+  pub fn delete(&mut self, item: impl Into<DatastoreEntity>) -> Result<(), DatastorersError> {
+    let entity: DatastoreEntity = item.into();
+    let base_version = entity.version();
+    let mut mutation = Mutation::default();
+
+    mutation.delete = entity.key();
+    mutation.base_version = base_version;
+
+    self.mutations.push(mutation);
+
+    Ok(())
+  }
+
+  pub fn commit(self) -> Result<(), DatastorersError> {
+    let client = self.connection.get_client();
+    let projects = client.projects();
+    let commit_request = projects.commit(
+      CommitRequest {
+          mode: None,
+          mutations: Some(self.mutations),
+          transaction: Some(self.transaction_id),
+      },
+      self.connection.get_project_name(),
+    );
+
+    let cr: CommitResponse = commit_request.execute()?;
+
+    // Validate result for conflicts
+    if let Some(results) = cr.mutation_results {
+      for result in results {
+        if let Some(conflict_detected) = result.conflict_detected {
+          if conflict_detected {
+            Err(DatastoreClientError::DataConflict)?
+          }
+        }
+      }
+    } else {
+      Err(DatastoreClientError::ApiDataError)?
+    }
+    Ok(())      
+  }
+}

--- a/tests/entity/main.rs
+++ b/tests/entity/main.rs
@@ -1,6 +1,6 @@
 use datastore_entity::{DatastoreEntity, DatastoreManaged};
-use std::convert::TryInto;
 use google_datastore1::schemas::Key;
+use std::convert::TryInto;
 
 #[derive(DatastoreManaged, Clone, Debug, Default)]
 #[kind = "thingy"]
@@ -13,6 +13,17 @@ pub struct Thing {
     pub prop_str_array: Vec<String>,
 }
 
+#[derive(DatastoreManaged, Clone, Debug, Default)]
+#[kind = "thingy"]
+pub struct VersionedThing {
+    #[key]
+    pub key_is_good: Option<Key>,
+
+    #[version]
+    pub thing_version: Option<i64>,
+
+    pub prop_string: String,
+}
 
 #[test]
 fn get_generated_properties() {
@@ -22,7 +33,24 @@ fn get_generated_properties() {
     assert_eq!(None, thing.id());
 }
 
+#[test]
+fn test_version() {
+    let test_version = 5345345;
+    let versioned_thing = VersionedThing {
+        key_is_good: Default::default(),
+        thing_version: Some(test_version),
+        prop_string: "StrStr".to_string(),
+    };
 
+    // From VersionedThing to DatastoreEntity, version shall be included in entity
+    let entity: DatastoreEntity = versioned_thing.clone().into();
+    assert_eq!(Some(test_version), entity.version());
+
+    // And back again
+    let thing_is_back: VersionedThing = entity.clone().try_into().unwrap();
+    assert_eq!(Some(test_version), thing_is_back.thing_version);
+    assert_eq!("StrStr", thing_is_back.prop_string);
+}
 
 #[test]
 fn into_datastore_entity_and_back() {
@@ -44,5 +72,8 @@ fn into_datastore_entity_and_back() {
     assert_eq!(777, thing_is_back.prop_integer);
     assert_eq!(thing.prop_boolean, thing_is_back.prop_boolean);
     assert_eq!(false, thing_is_back.prop_boolean);
-    assert_eq!(&vec![String::from("Str"), String::from("Array")], &thing.prop_str_array);
+    assert_eq!(
+        &vec![String::from("Str"), String::from("Array")],
+        &thing.prop_str_array
+    );
 }

--- a/tests/integration/connection.rs
+++ b/tests/integration/connection.rs
@@ -33,7 +33,7 @@ impl GoogleToken {
 }
 
 //
-// Implement a DatastoreCOnnection to be used in integration tests
+// Implement a DatastoreConnection to be used in integration tests
 //
 pub struct Connection {
   client: Client,


### PR DESCRIPTION
Now possible to create transactions that can read, commit and delete multiple entities within one single transaction.

Have a few ideas on how to change the transaction API, som maybe there will be some changes in a near future

The transaction commit method does not return the entities right now, this is because:
1. I did not find a good way to do it
2. It would have required the TransactionalConnection to clone ll entities in the transaction in order to have some data to return
3. I think the most common case is to do stuff and then commit the transaction once done :)