### PR TITLE
Introducing id! and name! declarative macros

### DIFF
--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -66,7 +66,7 @@ pub enum Identifier {
 ///
 /// Example:
 /// ```
-/// use datastorers::*;
+/// # use datastorers::*;
 /// #[derive(DatastoreManaged)]
 /// #[kind="my_entity"]
 /// struct MyEntity {
@@ -205,7 +205,7 @@ where
 ///
 /// Example:
 /// ```
-/// use datastorers::*;
+/// # use datastorers::*;
 /// #[derive(DatastoreManaged)]
 /// #[kind="my_entity"]
 /// struct MyEntity {
@@ -346,7 +346,7 @@ where
 ///
 /// Example:
 /// ```
-/// use datastorers::*;
+/// # use datastorers::*;
 /// #[derive(DatastoreManaged)]
 /// #[kind="my_entity"]
 /// struct MyEntity {
@@ -387,4 +387,100 @@ impl KeyPathElement for IdentifierNone {
     ) -> Result<Self, DatastorersError> {
         Ok(Self {})
     }
+}
+
+/// A macro for simplifying the creation of a chain of [IdentifierId](IdentifierId),
+/// [IdentifierName](IdentifierName), or [IdentifierNone](IdentifierNone) structs.
+///
+/// For example, writing:
+/// ```
+/// # use datastorers::*;
+/// # #[derive(DatastoreManaged)]
+/// # #[kind="my_entity"]
+/// # struct MyEntity {
+/// #     /// A key path with no ancestors and an identifier id of type i64
+/// #     #[key]
+/// #     key: IdentifierId<Self>,
+/// # }
+/// let key: IdentifierId<MyEntity> = id![5];
+/// ```
+/// is much easier than writing:
+/// ```
+/// # use datastorers::*;
+/// # #[derive(DatastoreManaged)]
+/// # #[kind="my_entity"]
+/// # struct MyEntity {
+/// #     /// A key path with no ancestors and an identifier id of type i64
+/// #     #[key]
+/// #     key: IdentifierId<Self>,
+/// # }
+/// let key: IdentifierId<MyEntity> = IdentifierId::id(Some(5), IdentifierNone::none());
+/// ```
+///
+/// See also [name!](name).
+#[macro_export]
+macro_rules! id {
+    // something like id![None, name![....
+    (None, $($tail:tt)*) => {
+        datastorers::IdentifierId::id(None, $($tail)*)
+    };
+    // something like id![5, name![....
+    ($lit: literal, $($tail:tt)*) => {
+        datastorers::IdentifierId::id(Some($lit), $($tail)*)
+    };
+    // something like id![None]
+    (None) => {
+        datastorers::IdentifierId::id(None, datastorers::IdentifierNone::none())
+    };
+    // something like id![5]
+    ($lit: literal) => {
+        datastorers::IdentifierId::id(Some($lit), datastorers::IdentifierNone::none())
+    };
+}
+
+/// A macro for simplifying the creation of a chain of [IdentifierId](IdentifierId),
+/// [IdentifierName](IdentifierName), or [IdentifierNone](IdentifierNone) structs.
+///
+/// For example, writing:
+/// ```
+/// # use datastorers::*;
+/// # #[derive(DatastoreManaged)]
+/// # #[kind="my_entity"]
+/// # struct MyEntity {
+/// #     #[key]
+/// #     key: IdentifierName<Self>,
+/// # }
+/// let key: IdentifierName<MyEntity> = name!["name"];
+/// ```
+/// is much easier than writing:
+/// ```
+/// # use datastorers::*;
+/// # #[derive(DatastoreManaged)]
+/// # #[kind="my_entity"]
+/// # struct MyEntity {
+/// #     #[key]
+/// #     key: IdentifierName<Self>,
+/// # }
+/// let key: IdentifierName<MyEntity> = IdentifierName::name(Some("name".to_string()), IdentifierNone::none());
+/// ```
+///
+/// See also [id!](id).
+#[macro_export]
+macro_rules! name {
+    // something like name![None, id![....
+    (None, $($tail:tt)*) => {
+        datastorers::IdentifierName::name(None, $($tail)*)
+    };
+    // something like name!["name", id![....
+    ($lit: literal, $($tail:tt)*) => {
+        datastorers::IdentifierName::name(Some($lit.to_string()), $($tail)*)
+    };
+    // something like name![None]
+    (None) => {
+        datastorers::IdentifierName::name(None, datastorers::IdentifierNone::none())
+    };
+    // something like name!["name"]
+    ($lit: literal) => {
+        datastorers::IdentifierName::name(Some($lit.to_string()), datastorers::IdentifierNone::none())
+    };
 }

--- a/tests/identifier/main.rs
+++ b/tests/identifier/main.rs
@@ -1,6 +1,6 @@
 use datastorers::{
-    DatastoreEntity, DatastoreKeyError, DatastoreManaged, DatastoreProperties, DatastorersError,
-    IdentifierId, IdentifierName, IdentifierNone, KeyPath, KeyPathElement, Kind,
+    id, name, DatastoreEntity, DatastoreKeyError, DatastoreManaged, DatastoreProperties,
+    DatastorersError, IdentifierId, IdentifierName, IdentifierNone, KeyPath, KeyPathElement, Kind,
 };
 use google_datastore1::schemas::{Key, PathElement};
 use std::convert::TryInto;
@@ -311,4 +311,49 @@ fn deserialize_from_entity_without_key() {
 
     // We couldn't find a key at all, which is an error
     assert_eq!(DatastoreKeyError::NoKey, error);
+}
+
+#[test]
+fn test_id_macro() {
+    let identifier: IdentifierId<KindA> = id![1001];
+    assert_eq!(1001, identifier.id.unwrap());
+}
+
+#[test]
+fn test_id_macro_none() {
+    let identifier: IdentifierId<KindA> = id![None];
+    assert_eq!(None, identifier.id);
+}
+
+#[test]
+fn test_name_macro() {
+    let identifier: IdentifierName<KindB> = name!["name"];
+    assert_eq!("name", identifier.name.unwrap());
+}
+
+#[test]
+fn test_name_macro_none() {
+    let identifier: IdentifierName<KindB> = name![None];
+    assert_eq!(None, identifier.name);
+}
+
+#[test]
+fn test_id_macro_name_macro() {
+    let identifier: IdentifierId<KindA, IdentifierName<KindB>> = id![2001, name!["thing"]];
+    assert_eq!(2001, identifier.id.unwrap());
+    assert_eq!("thing", identifier.ancestor.name.unwrap());
+}
+
+#[test]
+fn test_id_macro_none_name_macro() {
+    let identifier: IdentifierId<KindA, IdentifierName<KindB>> = id![None, name!["thing"]];
+    assert_eq!(None, identifier.id);
+    assert_eq!("thing", identifier.ancestor.name.unwrap());
+}
+
+#[test]
+fn test_name_macro_none_name_macro() {
+    let identifier: IdentifierName<KindA, IdentifierName<KindB>> = name![None, name!["thing"]];
+    assert_eq!(None, identifier.name);
+    assert_eq!("thing", identifier.ancestor.name.unwrap());
 }


### PR DESCRIPTION
These macros make it much easier to create chains of IdentifierId
and IdentifierName wherever there is an assignment, i.e. the type on the
left hand side of the statement is known.