### PR TITLE
Refactor IdentifierName and create a specialized type alias called IdentifierString

### DIFF
--- a/datastore_entity_derives/src/lib.rs
+++ b/datastore_entity_derives/src/lib.rs
@@ -1,7 +1,8 @@
 #![recursion_limit = "128"]
 #![allow(clippy::single_match)]
-
-extern crate proc_macro;
+#![warn(rust_2018_idioms)]
+#![warn(unused)]
+#![warn(rustdoc)]
 
 use proc_macro::TokenStream;
 use quote::quote;

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -23,7 +23,7 @@ impl AsRef<[u8]> for Bytes {
 }
 
 impl fmt::Display for Bytes {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         ::radix64::Display::new(BASE64_CFG, &self.0).fmt(f)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -62,6 +62,12 @@ pub enum DatastoreKeyError {
     ExpectedName,
 }
 
+#[derive(Error, Debug, PartialEq)]
+pub enum DatastoreNameRepresentationError {
+    #[error("Could not parse representation from given &str")]
+    ParseStrError,
+}
+
 #[derive(Error, Debug)]
 pub enum DatastorersError {
     #[error(transparent)]
@@ -76,4 +82,6 @@ pub enum DatastorersError {
     DatastoreDeserializeError(#[from] DatastoreDeserializeError),
     #[error(transparent)]
     DatastoreKeyError(#[from] DatastoreKeyError),
+    #[error(transparent)]
+    DatastoreNameRepresentationError(#[from] DatastoreNameRepresentationError),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
 #![allow(clippy::single_match)]
+#![warn(rust_2018_idioms)]
+#![warn(unused)]
+#![warn(rustdoc)]
 
 pub use crate::connection::DatastoreConnection;
 pub use crate::entity::{

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -5,7 +5,7 @@ use datastorers::transaction::TransactionConnection;
 use datastorers::DatastorersUpdatable;
 use datastorers::{
     id, name, DatastoreClientError, DatastoreManaged, DatastoreParseError, DatastorersError,
-    DatastorersQueryable, IdentifierId, IdentifierName, IdentifierNone, Kind, Operator, Order,
+    DatastorersQueryable, IdentifierId, IdentifierNone, IdentifierString, Kind, Operator, Order,
 };
 
 use crate::connection::create_test_connection;
@@ -63,7 +63,7 @@ pub struct TestEntityOptional {
 #[kind = "TestNameKey"]
 pub struct TestEntityName {
     #[key]
-    pub key: IdentifierName<Self>,
+    pub key: IdentifierString<Self>,
 
     pub prop_string: String,
 }


### PR DESCRIPTION
This commit introduces two helper traits and a type alias:

* SerializeIdentifierName, to serialize an identifier to String form.
* DeserializeIdentifierName, to deserialize an identifier from an &str.
* type alias IdentifierString, an alias for IdentifierName where Representation = String

This commit also implements SerializeIdentifierName and DeserializeIdentifierName for String.